### PR TITLE
Force a helm dependency update before releasing chart

### DIFF
--- a/release_helm_chart.sh
+++ b/release_helm_chart.sh
@@ -75,6 +75,7 @@ git tag -a v$1 -m "Helm chart version $2"
 git push origin v$1
 
 # Publish the chart
+helm dependency update servicex
 helm package servicex
 mv servicex-$2.tgz ../ssl-helm-charts
 


### PR DESCRIPTION
# Problem
If we change `requirements.yaml` the chart deployment script doesn't necessarily bundle matching sub charts into the published  chart.

# Approach
Add an explicit `helm dependency update` to insure that before publishing we refresh the sub charts to match the specification.