### PR TITLE
Fixes to avoid overwriting non-servicex tags

### DIFF
--- a/release_helm_chart.sh
+++ b/release_helm_chart.sh
@@ -63,7 +63,7 @@ mv servicex/Chart.new.yaml servicex/Chart.yaml
 git add servicex/Chart.yaml
 
 # Point all images in values.yaml to the new deployment
-sed -E -e "s/  tag:\s*.+$/  tag: $1/" -e "s/  defaultTransformerTag:\s*.+$/  defaultTransformerTag: $1/" servicex/values.yaml > servicex/values.new.yaml
+sed -E -e "s/  tag:\s*[[:digit:]]{8}-[[:digit:]]{4}-stable.*$/  tag: $1/" -e "s/  defaultTransformerTag:\s*.+$/  defaultTransformerTag: $1/" servicex/values.yaml > servicex/values.new.yaml
 
 mv servicex/values.new.yaml servicex/values.yaml
 git add servicex/values.yaml


### PR DESCRIPTION
Require tag: fields to be in calver before overwriting.  This fixes the problem where the memcached tag kept getting overwritten